### PR TITLE
Add readable veteran roles and friendships support and FFaker and seeds

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ gem 'figaro'
 gem 'geocoder'
 gem 'webpacker'
 gem 'react-rails'
+gem 'ffaker'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
     erubi (1.6.1)
     excon (0.59.0)
     execjs (2.7.0)
+    ffaker (2.7.0)
     ffi (1.9.18)
     figaro (1.1.1)
       thor (~> 0.14)
@@ -248,6 +249,7 @@ DEPENDENCIES
   carrierwave (~> 1.0)
   coffee-rails (~> 4.2)
   devise
+  ffaker
   figaro
   fog-aws
   font-awesome-rails

--- a/app/assets/javascripts/friendships.coffee
+++ b/app/assets/javascripts/friendships.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/friendships.scss
+++ b/app/assets/stylesheets/friendships.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Friendships controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,6 +1,6 @@
 class FriendshipsController < ApplicationController
   skip_before_action :verify_authenticity_token
-  
+
   def create
     veteran_id = friendship_params[:veteran_id]
     friend_id = friendship_params[:friend_id]

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,0 +1,24 @@
+class FriendshipsController < ApplicationController
+
+  def create
+    veteran_id = friendship_params[:veteran_id]
+    friend_id = friendship_params[:friend_id]
+    veteran = Veteran.find(veteran_id)
+    @friendship = veteran.friendships.build(friend_id: friend_id)
+    if @friendship.save
+      render json: @friendship
+    else
+      render json: @resource.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def friendship_params
+    params.require(:friendship).permit(
+      :veteran_id,
+      :friend_id,
+    )
+  end
+
+end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,10 +1,10 @@
 class FriendshipsController < ApplicationController
   skip_before_action :verify_authenticity_token
 
+  # POST /veterans/1/friendships
   def create
-    veteran_id = friendship_params[:veteran_id]
     friend_id = friendship_params[:friend_id]
-    veteran = Veteran.find(veteran_id)
+    veteran = Veteran.find(params[:veteran_id])
     @friendship = veteran.friendships.build(friend_id: friend_id)
     if @friendship.save
       render json: @friendship
@@ -13,11 +13,27 @@ class FriendshipsController < ApplicationController
     end
   end
 
+  # PATCH /veterans/1/friendships/reject
+  # Rejects a friend request sent to this veteran by
+  # removing the corresponding friendship with params
+  # veteran_id: <friend's id>, friend_id: <this veteran's id>
+  def reject
+    friend_id = friendship_params[:friend_id]
+    @friendship = Friendship.find_by(
+      veteran_id: friend_id,
+      friend_id: params[:veteran_id]
+    )
+    if @friendship.destroy
+      render json: @friendship
+    else
+      render json: @friendship.errors, status: :unprocessable_entity
+    end
+  end
+
   private
 
   def friendship_params
     params.require(:friendship).permit(
-      :veteran_id,
       :friend_id,
     )
   end

--- a/app/controllers/friendships_controller.rb
+++ b/app/controllers/friendships_controller.rb
@@ -1,5 +1,6 @@
 class FriendshipsController < ApplicationController
-
+  skip_before_action :verify_authenticity_token
+  
   def create
     veteran_id = friendship_params[:veteran_id]
     friend_id = friendship_params[:friend_id]

--- a/app/controllers/partnering_organizations/registrations_controller.rb
+++ b/app/controllers/partnering_organizations/registrations_controller.rb
@@ -40,12 +40,12 @@ class PartneringOrganizations::RegistrationsController < Devise::RegistrationsCo
 
   # If you have extra params to permit, append them to the sanitizer.
   def sign_up_params
-    params.require(:partnering_organization).permit(:email, :password, :password_confirmation, :name, :phone_number, :website, :address, :latitude, :longitude, :role, :demographic)
+    params.require(:partnering_organization).permit(:email, :password, :password_confirmation, :name, :phone_number, :website, :address, :lat, :lng, :role, :demographic)
   end
 
   # If you have extra params to permit, append them to the sanitizer.
   def account_update_params
-    params.require(:partnering_organization).permit(:email, :password, :password_confirmation, :name, :phone_number, :website, :address, :latitude, :longitude, :role, :demographic)
+    params.require(:partnering_organization).permit(:email, :password, :password_confirmation, :name, :phone_number, :website, :address, :lat, :lng, :role, :demographic)
 
   end
 

--- a/app/controllers/partnering_organizations_controller.rb
+++ b/app/controllers/partnering_organizations_controller.rb
@@ -1,10 +1,17 @@
-class PartneringOrganizationsController < ApplicationController 
+class PartneringOrganizationsController < ApplicationController
   before_action :set_partnering_organization, only: [:show, :edit, :update, :destroy]
 
   # GET /partnering_organizations
   # GET /partnering_organizations.json
   def index
     @partnering_organizations = PartneringOrganization.all
+    respond_to do |format|
+      format.html { render :index }
+      format.json {
+        render json: @partnering_organizations,
+               each_serializer: PartneringOrganizationSerializer
+      }
+    end
   end
 
   # GET /partnering_organizations/1
@@ -69,6 +76,6 @@ class PartneringOrganizationsController < ApplicationController
 
     # Never trust parameters from the scary internet, only allow the white list through.
     def partnering_organization_params
-      params.require(:partnering_organization).permit(:name, :phone_number, :website, :address, :latitude, :longitude, :role, :demographic)
+      params.require(:partnering_organization).permit(:name, :phone_number, :website, :address, :lat, :lng, :role, :demographic)
     end
 end

--- a/app/controllers/veterans/sessions_controller.rb
+++ b/app/controllers/veterans/sessions_controller.rb
@@ -1,6 +1,7 @@
 class Veterans::SessionsController < Devise::SessionsController
   respond_to :json
   skip_before_action :verify_authenticity_token
+
   # before_action :configure_sign_in_params, only: [:create]
 
   # GET /resource/sign_in

--- a/app/controllers/veterans_controller.rb
+++ b/app/controllers/veterans_controller.rb
@@ -92,8 +92,17 @@ class VeteransController < ApplicationController
     end
   end
 
+
   def get_military_branch
     render json: Veteran.military_branches
+  end
+
+  # Returns a list of all users that follow this user unreciprocated
+  # GET /veterans/1/requests
+  def requests
+    @veteran = Veteran.find(params[:id])
+    requesters = @veteran.followers - @veteran.follows
+    render json: requesters
   end
 
   private

--- a/app/controllers/veterans_controller.rb
+++ b/app/controllers/veterans_controller.rb
@@ -22,9 +22,8 @@ class VeteransController < ApplicationController
   # GET /veterans/1.json
   def show
     respond_to do |format|
-      format.html { render :index }
+      format.html { render :show }
       format.json {
-        puts "HEY"
         render json: @veteran,
                serializer: VeteranFriendSerializer,
                scope: { current_veteran: current_veteran }

--- a/app/controllers/veterans_controller.rb
+++ b/app/controllers/veterans_controller.rb
@@ -1,5 +1,6 @@
 class VeteransController < ApplicationController
   skip_before_action :verify_authenticity_token
+  before_action :authenticate_veteran!
   before_action :set_veteran, only: [:show, :edit, :update, :destroy]
 
 
@@ -7,12 +8,28 @@ class VeteransController < ApplicationController
   # GET /veterans.json
   def index
     @veterans = Veteran.all
+    respond_to do |format|
+      format.html { render :index }
+      format.json {
+        render json: @veterans,
+               each_serializer: VeteranFriendSerializer,
+               scope: { current_veteran: current_veteran }
+      }
+    end
   end
 
   # GET /veterans/1
   # GET /veterans/1.json
   def show
-    @veteran = Veteran.find(params[:id])
+    respond_to do |format|
+      format.html { render :index }
+      format.json {
+        puts "HEY"
+        render json: @veteran,
+               serializer: VeteranFriendSerializer,
+               scope: { current_veteran: current_veteran }
+      }
+    end
   end
 
   # GET /veterans/new

--- a/app/helpers/friendships_helper.rb
+++ b/app/helpers/friendships_helper.rb
@@ -1,0 +1,2 @@
+module FriendshipsHelper
+end

--- a/app/models/abilities/admin_ability.rb
+++ b/app/models/abilities/admin_ability.rb
@@ -11,7 +11,7 @@ class AdminAbility
     ], Admin, id: admin.id
 
     can [
-      :index, 
+      :index,
       :destroy,
     ], PartneringOrganization
 
@@ -21,7 +21,5 @@ class AdminAbility
     ], Veteran
 
     can :manage, Resource
-    can :manage, PartneringOrganization
-    can :manage, Veteran
   end
 end

--- a/app/models/abilities/veteran_ability.rb
+++ b/app/models/abilities/veteran_ability.rb
@@ -1,0 +1,27 @@
+class VeteranAbility
+  include CanCan::Ability
+
+  def initialize(veteran)
+    veteran ||= Veteran.new
+
+    can [
+      :index,
+    ], Veteran
+
+    can [
+      :show,
+      :update,
+      :destroy,
+    ], Veteran, id: veteran.id
+
+    can [
+      :index,
+    ], PartneringOrganization
+
+    can [
+      :index,
+      :show,
+    ], Resource
+
+  end
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -12,4 +12,6 @@
 class Friendship < ApplicationRecord
   belongs_to :veteran
   belongs_to :friend, class_name: 'Veteran'
+
+  validates_uniqueness_of :veteran_id, scope: :friend_id
 end

--- a/app/models/partnering_organization.rb
+++ b/app/models/partnering_organization.rb
@@ -7,8 +7,8 @@
 #  phone_number           :string
 #  website                :string
 #  address                :string
-#  latitude               :float
-#  longitude              :float
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #  role                   :integer
 #  demographic            :integer
 #  created_at             :datetime         not null

--- a/app/models/partnering_organization.rb
+++ b/app/models/partnering_organization.rb
@@ -26,12 +26,31 @@
 #
 
 class PartneringOrganization < ApplicationRecord
-	geocoded_by :address
-	after_validation :geocode
+
 	devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-	enum role: [:caregiver, :support_team, :educator, :volunteer_organization, :awareness_team]
-  enum demographic: [:active_duty, :veterans, :family_members, :children, :victims_of_violence, :suicide_prevention, :drugs_and_alcohol]
-  has_many :resources, :as => :owner, dependent: :destroy
+
+	has_many :resources, :as => :owner, dependent: :destroy
+
+	enum role: [
+		:caregiver,
+		:support_team,
+		:educator,
+		:volunteer_organization,
+		:awareness_team
+	]
+
+  enum demographic: [
+		:active_duty,
+		:veterans,
+		:family_members,
+		:children,
+		:victims_of_violence,
+		:suicide_prevention,
+		:drugs_and_alcohol
+	]
+
+	geocoded_by :address
+	after_validation :geocode
 
 end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -25,6 +25,8 @@
 #  accept_messages        :boolean
 #  share_profile          :boolean
 #  accept_notices         :boolean
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #
 
 class Veteran < ApplicationRecord

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -91,6 +91,10 @@ class Veteran < ApplicationRecord
     follows.exists?(other.id) && followers.exists?(other.id)
   end
 
+  def sent_friend_request_to?(other)
+    follows.exists?(other.id)
+  end
+
   private
 
   def correctly_serialized_roles

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -51,28 +51,38 @@ class Veteran < ApplicationRecord
 
   enum military_branch: {Army: 1, Navy: 2, Marines: 3, Air_Force: 4, Coast_Guard: 5, First_Responder: 6}
 
-  def self.role_names
-    [
-      :active_duty,
-      :veteran,
-      :post_911,
-      :family_member,
-      :caregiver,
-      :other,
-    ]
-  end
+  ROLE_KEYS = [
+    :active_duty,
+    :veteran,
+    :post_911,
+    :family_member,
+    :caregiver,
+    :other,
+  ]
+
+  ROLE_NAMES = {
+    active_duty:    'Active Duty',
+    veteran:        'Veteran',
+    post_911:       'Post 911',
+    family_member:  'Family Member',
+    caregiver:      'Caregiver',
+    other:          'Other',
+  }
 
   # Accepts an array of string roles and returns the serialized integer version
   def self.serialize_string_roles(arr)
     if arr.nil?
       return
     end
-    arr.map { |s| Veteran.role_names.index(s.to_sym) }
+    arr.map { |s| ROLE_KEYS.index(s.to_sym) }
   end
 
   def string_roles
-    role = Veteran.role_names
-    roles.map { |r| role[r].to_s }
+    roles.map { |r| ROLE_KEYS[r].to_s }
+  end
+
+  def readable_roles
+    roles.map { |r| ROLE_NAMES[ROLE_KEYS[r]] }
   end
 
   private
@@ -83,7 +93,7 @@ class Veteran < ApplicationRecord
       return
     end
     self.roles.each do |r|
-      unless r.is_a?(Integer) && r < Veteran.role_names.length
+      unless r.is_a?(Integer) && r < ROLE_KEYS.length
         errors.add(:roles, 'are not well defined.')
       end
     end

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -51,7 +51,14 @@ class Veteran < ApplicationRecord
 
   serialize :roles
 
-  enum military_branch: {Army: 1, Navy: 2, Marines: 3, Air_Force: 4, Coast_Guard: 5, First_Responder: 6}
+  enum military_branch: {
+    Army: 1,
+    Navy: 2,
+    Marines: 3,
+    Air_Force: 4,
+    Coast_Guard: 5,
+    First_Responder: 6
+  }
 
   ROLE_KEYS = [
     :active_duty,

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -34,7 +34,7 @@ class Veteran < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
   has_many :friendships
-  has_many :follows, through: :friendships
+  has_many :follows, through: :friendships, source: :friend
 
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
   has_many :followers, through: :inverse_friendships, source: :veteran
@@ -83,6 +83,10 @@ class Veteran < ApplicationRecord
 
   def readable_roles
     roles.map { |r| ROLE_NAMES[ROLE_KEYS[r]] }
+  end
+
+  def is_friend_of?(other)
+    follows.exists?(other.id) && followers.exists?(other.id)
   end
 
   private

--- a/app/serializers/base_veteran_serializer.rb
+++ b/app/serializers/base_veteran_serializer.rb
@@ -21,13 +21,11 @@
 #  last_sign_in_ip        :inet
 #
 
-class VeteranSerializer < BaseVeteranSerializer
-
-  def roles
-    object.readable_roles
-  end
-
-  # def is_friend
-  #   current_veteran.is_friend_of?(object)
-  # end
+class BaseVeteranSerializer < BaseSerializer
+  attributes :id,
+             :first_name,
+             :last_name,
+             :on_connect,
+             :roles,
+             :email
 end

--- a/app/serializers/base_veteran_serializer.rb
+++ b/app/serializers/base_veteran_serializer.rb
@@ -1,31 +1,10 @@
-# == Schema Information
-#
-# Table name: veterans
-#
-#  id                     :integer          not null, primary key
-#  first_name             :string
-#  last_name              :string
-#  on_connect             :boolean          default(FALSE)
-#  created_at             :datetime         not null
-#  updated_at             :datetime         not null
-#  roles                  :text             default("[]")
-#  email                  :string           default(""), not null
-#  encrypted_password     :string           default(""), not null
-#  reset_password_token   :string
-#  reset_password_sent_at :datetime
-#  remember_created_at    :datetime
-#  sign_in_count          :integer          default(0), not null
-#  current_sign_in_at     :datetime
-#  last_sign_in_at        :datetime
-#  current_sign_in_ip     :inet
-#  last_sign_in_ip        :inet
-#
-
 class BaseVeteranSerializer < BaseSerializer
   attributes :id,
              :first_name,
              :last_name,
              :on_connect,
              :roles,
-             :email
+             :email,
+             :lat,
+             :lng
 end

--- a/app/serializers/partnering_organization_serializer.rb
+++ b/app/serializers/partnering_organization_serializer.rb
@@ -7,8 +7,8 @@
 #  phone_number           :string
 #  website                :string
 #  address                :string
-#  latitude               :float
-#  longitude              :float
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #  role                   :integer
 #  demographic            :integer
 #  created_at             :datetime         not null
@@ -31,8 +31,8 @@ class PartneringOrganizationSerializer < BaseSerializer
              :phone_number,
              :website,
              :address,
-             :latitude,
-             :longitude,
+             :lat,
+             :lng,
              :role,
              :demographic
 end

--- a/app/serializers/veteran_friend_serializer.rb
+++ b/app/serializers/veteran_friend_serializer.rb
@@ -1,5 +1,6 @@
 class VeteranFriendSerializer < BaseVeteranSerializer
   attribute :is_friend
+  attribute :sent_friend_request
 
   def roles
     object.readable_roles
@@ -7,5 +8,9 @@ class VeteranFriendSerializer < BaseVeteranSerializer
 
   def is_friend
     scope[:current_veteran].is_friend_of?(object)
+  end
+
+  def sent_friend_request
+    scope[:current_veteran].sent_friend_request_to?(object)
   end
 end

--- a/app/serializers/veteran_friend_serializer.rb
+++ b/app/serializers/veteran_friend_serializer.rb
@@ -1,0 +1,11 @@
+class VeteranFriendSerializer < BaseVeteranSerializer
+  attribute :is_friend
+
+  def roles
+    object.readable_roles
+  end
+
+  def is_friend
+    scope[:current_veteran].is_friend_of?(object)
+  end
+end

--- a/app/serializers/veteran_serializer.rb
+++ b/app/serializers/veteran_serializer.rb
@@ -30,6 +30,6 @@ class VeteranSerializer < BaseSerializer
              :email
 
   def roles
-    object.string_roles
-  end 
+    object.readable_roles
+  end
 end

--- a/app/serializers/veteran_serializer.rb
+++ b/app/serializers/veteran_serializer.rb
@@ -29,7 +29,4 @@ class VeteranSerializer < BaseVeteranSerializer
     object.readable_roles
   end
 
-  # def is_friend
-  #   current_veteran.is_friend_of?(object)
-  # end
 end

--- a/app/serializers/veteran_serializer.rb
+++ b/app/serializers/veteran_serializer.rb
@@ -21,6 +21,12 @@
 #  last_sign_in_ip        :inet
 #  lat                    :decimal(10, 6)
 #  lng                    :decimal(10, 6)
+#  military_branch        :integer
+#  unit                   :string
+#  notes                  :string
+#  accept_messages        :boolean
+#  share_profile          :boolean
+#  accept_notices         :boolean
 #
 
 class VeteranSerializer < BaseVeteranSerializer

--- a/app/serializers/veteran_serializer.rb
+++ b/app/serializers/veteran_serializer.rb
@@ -19,6 +19,8 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #
 
 class VeteranSerializer < BaseVeteranSerializer

--- a/app/views/partnering_organizations/_form.html.erb
+++ b/app/views/partnering_organizations/_form.html.erb
@@ -32,13 +32,13 @@
   </div>
 
   <div class="field">
-    <%= form.label :latitude %>
-    <%= form.text_field :latitude, id: :partnering_organization_latitude %>
+    <%= form.label :lat %>
+    <%= form.text_field :lat, id: :partnering_organization_lat %>
   </div>
 
   <div class="field">
-    <%= form.label :longitude %>
-    <%= form.text_field :longitude, id: :partnering_organization_longitude %>
+    <%= form.label :lng %>
+    <%= form.text_field :lng, id: :partnering_organization_lng %>
   </div>
 
   <div class="field">

--- a/app/views/partnering_organizations/_partnering_organization.json.jbuilder
+++ b/app/views/partnering_organizations/_partnering_organization.json.jbuilder
@@ -1,2 +1,2 @@
-json.extract! partnering_organization, :id, :name, :phone_number, :website, :address, :latitude, :longitude, :role, :demographic, :created_at, :updated_at
+json.extract! partnering_organization, :id, :name, :phone_number, :website, :address, :lat, :lng, :role, :demographic, :created_at, :updated_at
 json.url partnering_organization_url(partnering_organization, format: :json)

--- a/app/views/partnering_organizations/index.html.erb
+++ b/app/views/partnering_organizations/index.html.erb
@@ -24,8 +24,8 @@
         <td><%= partnering_organization.phone_number %></td>
         <td><%= partnering_organization.website %></td>
         <td><%= partnering_organization.address %></td>
-        <td><%= partnering_organization.latitude %></td>
-        <td><%= partnering_organization.longitude %></td>
+        <td><%= partnering_organization.lat %></td>
+        <td><%= partnering_organization.lng %></td>
         <td><%= partnering_organization.role %></td>
         <td><%= partnering_organization.demographic %></td>
         <td><%= link_to 'Show', partnering_organization %></td>

--- a/app/views/partnering_organizations/show.html.erb
+++ b/app/views/partnering_organizations/show.html.erb
@@ -21,7 +21,14 @@
 </p>
 
 <p>
- 
+  <strong>Latitude:</strong>
+  <%= @partnering_organization.lat %>
+</p>
+
+<p>
+  <strong>Longitude:</strong>
+  <%= @partnering_organization.lng %>
+</p>
 
 <p>
   <strong>Role:</strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,13 +12,19 @@ Rails.application.routes.draw do
   devise_for :admins
 
   resources :veterans do
-    resources :friendships, only: [:create]
     member do
       get :requests
       patch 'connect_sign_up', to: 'veterans#connect_sign_up'
     end
     collection do
       get 'get_military_branch'
+    end
+
+    # Friendships
+    resources :friendships, only: [:create] do
+      collection do
+        patch :reject 
+      end
     end
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   devise_for :admins
 
   resources :veterans do
+    resources :friendships, only: [:create]
     member do
       patch 'connect_sign_up', to: 'veterans#connect_sign_up'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,6 +14,7 @@ Rails.application.routes.draw do
   resources :veterans do
     resources :friendships, only: [:create]
     member do
+      get :requests
       patch 'connect_sign_up', to: 'veterans#connect_sign_up'
     end
     collection do

--- a/db/migrate/20171120013142_add_lat_lng_to_veterans.rb
+++ b/db/migrate/20171120013142_add_lat_lng_to_veterans.rb
@@ -1,0 +1,6 @@
+class AddLatLngToVeterans < ActiveRecord::Migration[5.1]
+  def change
+    add_column :veterans, :lat, :decimal, { precision: 10, scale: 6 }
+    add_column :veterans, :lng, :decimal, { precision: 10, scale: 6 }
+  end
+end

--- a/db/migrate/20171120013453_change_lat_lng_of_partering_orgs.rb
+++ b/db/migrate/20171120013453_change_lat_lng_of_partering_orgs.rb
@@ -1,0 +1,8 @@
+class ChangeLatLngOfParteringOrgs < ActiveRecord::Migration[5.1]
+  def change
+    rename_column :partnering_organizations, :latitude, :lat
+    rename_column :partnering_organizations, :longitude, :lng
+    change_column :partnering_organizations, :lat, :decimal, { precision: 10, scale: 6 }
+    change_column :partnering_organizations, :lng, :decimal, { precision: 10, scale: 6 }
+  end
+end

--- a/db/migrate/20171128020202_add_primary_key_index_to_friendships.rb
+++ b/db/migrate/20171128020202_add_primary_key_index_to_friendships.rb
@@ -1,0 +1,5 @@
+class AddPrimaryKeyIndexToFriendships < ActiveRecord::Migration[5.1]
+  def change
+    add_index :friendships, [:veteran_id, :friend_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171116014836) do
+ActiveRecord::Schema.define(version: 20171120013453) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,8 +49,8 @@ ActiveRecord::Schema.define(version: 20171116014836) do
     t.string "phone_number"
     t.string "website"
     t.string "address"
-    t.float "latitude"
-    t.float "longitude"
+    t.decimal "lat", precision: 10, scale: 6
+    t.decimal "lng", precision: 10, scale: 6
     t.integer "role"
     t.integer "demographic"
     t.datetime "created_at", null: false
@@ -78,7 +78,6 @@ ActiveRecord::Schema.define(version: 20171116014836) do
     t.bigint "partnering_organizations_id"
     t.string "owner_type"
     t.bigint "owner_id"
-    t.string "description"
     t.index ["owner_type", "owner_id"], name: "index_resources_on_owner_type_and_owner_id"
     t.index ["partnering_organizations_id"], name: "index_resources_on_partnering_organizations_id"
   end
@@ -100,6 +99,8 @@ ActiveRecord::Schema.define(version: 20171116014836) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
+    t.decimal "lat", precision: 10, scale: 6
+    t.decimal "lng", precision: 10, scale: 6
     t.integer "military_branch"
     t.string "unit"
     t.string "notes"
@@ -110,4 +111,5 @@ ActiveRecord::Schema.define(version: 20171116014836) do
     t.index ["reset_password_token"], name: "index_veterans_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "resources", "partnering_organizations", column: "partnering_organizations_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120013453) do
+ActiveRecord::Schema.define(version: 20171128020202) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -41,6 +41,7 @@ ActiveRecord::Schema.define(version: 20171120013453) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["friend_id"], name: "index_friendships_on_friend_id"
+    t.index ["veteran_id", "friend_id"], name: "index_friendships_on_veteran_id_and_friend_id", unique: true
     t.index ["veteran_id"], name: "index_friendships_on_veteran_id"
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,11 +1,3 @@
-# This file should contain all the record creation needed to seed the database with its default values.
-# The data can then be loaded with the rails db:seed command (or created alongside the database with db:setup).
-#
-# Examples:
-#
-#   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
-#   Character.create(name: 'Luke', movie: movies.first)
-
 # Create Veterans
 def create_veterans
   veterans = []
@@ -39,13 +31,13 @@ def create_veterans
       end
     end
   end
-
 end
 
 
 # Create Partering Orgs
 def create_partering_orgs
   rng = Random.new(934857239324211115710)
+  
   10.times do |i|
     po = PartneringOrganization.create(
       name: FFaker::Company.name,

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,7 +10,9 @@
 def create_veterans
   veterans = []
   rng = Random.new(934857239324211115710)
+  num_roles = Veteran::ROLE_KEYS.count
 
+  # Create 10 Veterans with random names and some random roles
   10.times do |i|
     veteran = Veteran.create(
       first_name: FFaker::Name.first_name,
@@ -18,13 +20,14 @@ def create_veterans
       email: "veteran#{i}@gmail.com",
       password: 'password',
       password_confirmation: 'password',
-      roles: Array(0..5).sample(rng.rand(6) + 1)
+      roles: Array(0...num_roles).sample(rng.rand(num_roles) + 1)
     )
     veterans << veteran
   end
 
+  # Create 0-5 friendships for each veteran
   veterans.each do |veteran|
-    rng.rand(5).times do |i|
+    rng.rand(6).times do |i|
       friendship = Friendship.new(
         veteran_id: veteran.id,
         friend_id: rng.rand(10) + 1
@@ -37,4 +40,30 @@ def create_veterans
 
 end
 
-create_veterans 
+
+# Create Partering Orgs
+def create_partering_orgs
+  rng = Random.new(934857239324211115710)
+  10.times do |i|
+    po = PartneringOrganization.create(
+      name: FFaker::Company.name,
+      email: "po#{i}@gmail.com",
+      password: 'password',
+      password_confirmation: 'password',
+      phone_number: FFaker::PhoneNumber.short_phone_number,
+      website: FFaker::Product.product.gsub(/\s+/, "").downcase + '.com',
+      address: FFaker::AddressUS.street_address + ', ' +
+               FFaker::AddressUS.city + ', ' +
+               FFaker::AddressUS.state_abbr + ' ' +
+               FFaker::AddressUS.zip_code,
+      latitude: FFaker::Geolocation.lat,
+      longitude: FFaker::Geolocation.lng,
+      role: rng.rand(PartneringOrganization.roles.count),
+      demographic: rng.rand(PartneringOrganization.demographics.count),
+    )
+  end
+end
+
+
+create_veterans
+create_partering_orgs

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -20,7 +20,9 @@ def create_veterans
       email: "veteran#{i}@gmail.com",
       password: 'password',
       password_confirmation: 'password',
-      roles: Array(0...num_roles).sample(rng.rand(num_roles) + 1)
+      roles: Array(0...num_roles).sample(rng.rand(num_roles) + 1),
+      lat: FFaker::Geolocation.lat,
+      lng: FFaker::Geolocation.lng,
     )
     veterans << veteran
   end
@@ -56,8 +58,8 @@ def create_partering_orgs
                FFaker::AddressUS.city + ', ' +
                FFaker::AddressUS.state_abbr + ' ' +
                FFaker::AddressUS.zip_code,
-      latitude: FFaker::Geolocation.lat,
-      longitude: FFaker::Geolocation.lng,
+      lat: FFaker::Geolocation.lat,
+      lng: FFaker::Geolocation.lng,
       role: rng.rand(PartneringOrganization.roles.count),
       demographic: rng.rand(PartneringOrganization.demographics.count),
     )

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,36 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+# Create Veterans
+def create_veterans
+  veterans = []
+  rng = Random.new(934857239324211115710)
+
+  10.times do |i|
+    veteran = Veteran.create(
+      first_name: FFaker::Name.first_name,
+      last_name: FFaker::Name.last_name,
+      email: "veteran#{i}@gmail.com",
+      password: 'password',
+      password_confirmation: 'password',
+      roles: Array(0..5).sample(rng.rand(6) + 1)
+    )
+    veterans << veteran
+  end
+
+  veterans.each do |veteran|
+    rng.rand(5).times do |i|
+      friendship = Friendship.new(
+        veteran_id: veteran.id,
+        friend_id: rng.rand(10) + 1
+      )
+      unless friendship.veteran_id == friendship.friend_id
+        friendship.save
+      end
+    end
+  end
+
+end
+
+create_veterans 

--- a/test/controllers/friendships_controller_test.rb
+++ b/test/controllers/friendships_controller_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class FriendshipsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/controllers/partnering_organizations_controller_test.rb
+++ b/test/controllers/partnering_organizations_controller_test.rb
@@ -17,7 +17,7 @@ class PartneringOrganizationsControllerTest < ActionDispatch::IntegrationTest
 
   test "should create partnering_organization" do
     assert_difference('PartneringOrganization.count') do
-      post partnering_organizations_url, params: { partnering_organization: { address: @partnering_organization.address, demographic: @partnering_organization.demographic, latitude: @partnering_organization.latitude, longitude: @partnering_organization.longitude, name: @partnering_organization.name, phone_number: @partnering_organization.phone_number, role: @partnering_organization.role, website: @partnering_organization.website } }
+      post partnering_organizations_url, params: { partnering_organization: { address: @partnering_organization.address, demographic: @partnering_organization.demographic, lat: @partnering_organization.lat, lng: @partnering_organization.lng, name: @partnering_organization.name, phone_number: @partnering_organization.phone_number, role: @partnering_organization.role, website: @partnering_organization.website } }
     end
 
     assert_redirected_to partnering_organization_url(PartneringOrganization.last)
@@ -34,7 +34,7 @@ class PartneringOrganizationsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "should update partnering_organization" do
-    patch partnering_organization_url(@partnering_organization), params: { partnering_organization: { address: @partnering_organization.address, demographic: @partnering_organization.demographic, latitude: @partnering_organization.latitude, longitude: @partnering_organization.longitude, name: @partnering_organization.name, phone_number: @partnering_organization.phone_number, role: @partnering_organization.role, website: @partnering_organization.website } }
+    patch partnering_organization_url(@partnering_organization), params: { partnering_organization: { address: @partnering_organization.address, demographic: @partnering_organization.demographic, lat: @partnering_organization.lat, lng: @partnering_organization.lng, name: @partnering_organization.name, phone_number: @partnering_organization.phone_number, role: @partnering_organization.role, website: @partnering_organization.website } }
     assert_redirected_to partnering_organization_url(@partnering_organization)
   end
 

--- a/test/fixtures/partnering_organizations.yml
+++ b/test/fixtures/partnering_organizations.yml
@@ -7,8 +7,8 @@
 #  phone_number           :string
 #  website                :string
 #  address                :string
-#  latitude               :float
-#  longitude              :float
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #  role                   :integer
 #  demographic            :integer
 #  created_at             :datetime         not null

--- a/test/fixtures/partnering_organizations.yml
+++ b/test/fixtures/partnering_organizations.yml
@@ -32,8 +32,8 @@ one:
   phone_number: MyString
   website: MyString
   address: MyString
-  latitude: 1.5
-  longitude: 1.5
+  lat: 1.5
+  lng: 1.5
   role: 1
   demographic: 1
 
@@ -42,7 +42,7 @@ two:
   phone_number: MyString
   website: MyString
   address: MyString
-  latitude: 1.5
-  longitude: 1.5
+  lat: 1.5
+  lng: 1.5
   role: 1
   demographic: 1

--- a/test/fixtures/veterans.yml
+++ b/test/fixtures/veterans.yml
@@ -21,6 +21,12 @@
 #  last_sign_in_ip        :inet
 #  lat                    :decimal(10, 6)
 #  lng                    :decimal(10, 6)
+#  military_branch        :integer
+#  unit                   :string
+#  notes                  :string
+#  accept_messages        :boolean
+#  share_profile          :boolean
+#  accept_notices         :boolean
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/fixtures/veterans.yml
+++ b/test/fixtures/veterans.yml
@@ -19,6 +19,8 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/models/veteran_test.rb
+++ b/test/models/veteran_test.rb
@@ -21,6 +21,12 @@
 #  last_sign_in_ip        :inet
 #  lat                    :decimal(10, 6)
 #  lng                    :decimal(10, 6)
+#  military_branch        :integer
+#  unit                   :string
+#  notes                  :string
+#  accept_messages        :boolean
+#  share_profile          :boolean
+#  accept_notices         :boolean
 #
 
 require 'test_helper'

--- a/test/models/veteran_test.rb
+++ b/test/models/veteran_test.rb
@@ -19,6 +19,8 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  lat                    :decimal(10, 6)
+#  lng                    :decimal(10, 6)
 #
 
 require 'test_helper'


### PR DESCRIPTION
* Adds support for veterans to friend each other on the back end
    * Adds Friendships controller
* Adds friendship info to be returned by the serializer so mobile can get that info
* Adds seeds for veterans
* Adds seeds for POs

Serializer now returns this with the `is_friend` field: 
```bash
17:23:18:   Object {
17:23:18:     "email": "veteran9@gmail.com",
17:23:18:     "first_name": "Suzy",
17:23:18:     "id": 28,
17:23:18:     "is_friend": false,
17:23:18:     "last_name": "Bashirian",
17:23:18:     "on_connect": false,
17:23:18:     "roles": Array [
17:23:18:       "Post 911",
17:23:18:       "Family Member",
17:23:18:     ],
17:23:18:   },
17:23:18:   Object {
17:23:18:     "email": "lbkchen@gmail.com",
17:23:18:     "first_name": "Ken",
17:23:18:     "id": 8,
17:23:18:     "is_friend": true,
17:23:18:     "last_name": "Chen",
17:23:18:     "on_connect": false,
17:23:18:     "roles": Array [
17:23:18:       "Post 911",
17:23:18:       "Family Member",
17:23:18:     ],
17:23:18:   },
```