### PR TITLE
Add support for subscribing to PO's

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ capybara-*.html
 /db/*.sqlite3
 /db/*.sqlite3-journal
 /public/system
+/public/uploads/tmp
 /coverage/
 /spec/tmp
 *.orig

--- a/app/assets/javascripts/subscriptions.coffee
+++ b/app/assets/javascripts/subscriptions.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/subscriptions.scss
+++ b/app/assets/stylesheets/subscriptions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Subscriptions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/partnering_organizations_controller.rb
+++ b/app/controllers/partnering_organizations_controller.rb
@@ -5,11 +5,13 @@ class PartneringOrganizationsController < ApplicationController
   # GET /partnering_organizations.json
   def index
     @partnering_organizations = PartneringOrganization.all
+    serializer = veteran_signed_in? ? PartneringOrganizationSubscriptionsSerializer : PartneringOrganizationSerializer
     respond_to do |format|
       format.html { render :index }
       format.json {
         render json: @partnering_organizations,
-               each_serializer: PartneringOrganizationSerializer
+               each_serializer: PartneringOrganizationSubscriptionsSerializer,
+               scope: { current_veteran: current_veteran }
       }
     end
   end

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,5 +1,6 @@
 class SubscriptionsController < ApplicationController
-
+  skip_before_action :verify_authenticity_token
+  
   # POST /veterans/1/subscriptions
   def create
     po_id = subscription_params[:partnering_organization_id]

--- a/app/controllers/subscriptions_controller.rb
+++ b/app/controllers/subscriptions_controller.rb
@@ -1,0 +1,24 @@
+class SubscriptionsController < ApplicationController
+
+  # POST /veterans/1/subscriptions
+  def create
+    po_id = subscription_params[:partnering_organization_id]
+    veteran = Veteran.find(params[:veteran_id])
+    @subscription = veteran.subscriptions.build(
+      partnering_organization_id: po_id
+    )
+    if @subscription.save
+      render json: @subscription
+    else
+      render json: @subscription.errors, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def subscription_params
+    params.require(:subscription).permit(
+      :partnering_organization_id,
+    )
+  end
+end

--- a/app/helpers/subscriptions_helper.rb
+++ b/app/helpers/subscriptions_helper.rb
@@ -1,0 +1,2 @@
+module SubscriptionsHelper
+end

--- a/app/models/friendship.rb
+++ b/app/models/friendship.rb
@@ -12,6 +12,6 @@
 class Friendship < ApplicationRecord
   belongs_to :veteran
   belongs_to :friend, class_name: 'Veteran'
-
+  
   validates_uniqueness_of :veteran_id, scope: :friend_id
 end

--- a/app/models/partnering_organization.rb
+++ b/app/models/partnering_organization.rb
@@ -23,6 +23,7 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  image                  :string
 #
 
 class PartneringOrganization < ApplicationRecord

--- a/app/models/partnering_organization.rb
+++ b/app/models/partnering_organization.rb
@@ -31,6 +31,10 @@ class PartneringOrganization < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable
 
 	has_many :resources, :as => :owner, dependent: :destroy
+
+	has_many :subscriptions
+	has_many :subscribers, through: :subscriptions, source: :veteran
+
   mount_uploader :image, ImageUploader
 
 	enum role: [

--- a/app/models/resource.rb
+++ b/app/models/resource.rb
@@ -5,12 +5,13 @@
 #  id                          :integer          not null, primary key
 #  file_name                   :string
 #  file                        :string
-#  category                    :string
+#  category                    :integer
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  partnering_organizations_id :integer
 #  owner_type                  :string
 #  owner_id                    :integer
+#  description                 :string
 #
 
 class Resource < ApplicationRecord

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subscriptions
+#
+#  id                         :integer          not null, primary key
+#  veteran_id                 :integer
+#  partnering_organization_id :integer
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+
 class Subscription < ApplicationRecord
   belongs_to :veteran
   belongs_to :partnering_organization

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,4 +1,6 @@
 class Subscription < ApplicationRecord
   belongs_to :veteran
   belongs_to :partnering_organization
+
+  validates_uniqueness_of :veteran_id, scope: :partnering_organization_id
 end

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -1,0 +1,4 @@
+class Subscription < ApplicationRecord
+  belongs_to :veteran
+  belongs_to :partnering_organization
+end

--- a/app/models/upvote.rb
+++ b/app/models/upvote.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: upvotes
+#
+#  id          :integer          not null, primary key
+#  veteran_id  :integer
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class Upvote < ApplicationRecord
   belongs_to :veteran
   belongs_to :resource

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -35,7 +35,7 @@ class Veteran < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
 
-  has_many :upvotes, :dependent => :destroy
+  has_many :upvotes, dependent: :destroy
   has_many :resources, through: :upvotes
 
   has_many :friendships
@@ -43,6 +43,9 @@ class Veteran < ApplicationRecord
 
   has_many :inverse_friendships, class_name: 'Friendship', foreign_key: 'friend_id'
   has_many :followers, through: :inverse_friendships, source: :veteran
+
+  has_many :subscriptions
+  has_many :po_follows, through: :subscriptions, source: :partnering_organization
 
   EMAIL_PATTERN = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/i
   validates_confirmation_of :password

--- a/app/models/veteran.rb
+++ b/app/models/veteran.rb
@@ -108,6 +108,10 @@ class Veteran < ApplicationRecord
     follows.exists?(other.id)
   end
 
+  def is_subscribed_to?(po)
+    po_follows.exists?(po.id)
+  end
+
   private
 
   def correctly_serialized_roles

--- a/app/serializers/partnering_organization_serializer.rb
+++ b/app/serializers/partnering_organization_serializer.rb
@@ -23,6 +23,7 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  image                  :string
 #
 
 class PartneringOrganizationSerializer < BaseSerializer

--- a/app/serializers/partnering_organization_subscriptions_serializer.rb
+++ b/app/serializers/partnering_organization_subscriptions_serializer.rb
@@ -1,0 +1,8 @@
+class PartneringOrganizationSubscriptionsSerializer < PartneringOrganizationSerializer
+  attribute :is_subscribed_to
+
+  # Tells whether the current veteran is subscribed to this PO
+  def is_subscribed_to
+    scope[:current_veteran].is_subscribed_to?(object)
+  end
+end

--- a/app/serializers/resource_serializer.rb
+++ b/app/serializers/resource_serializer.rb
@@ -5,12 +5,13 @@
 #  id                          :integer          not null, primary key
 #  file_name                   :string
 #  file                        :string
-#  category                    :string
+#  category                    :integer
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  partnering_organizations_id :integer
 #  owner_type                  :string
 #  owner_id                    :integer
+#  description                 :string
 #
 
 class ResourceSerializer < BaseSerializer

--- a/app/serializers/upvote_serializer.rb
+++ b/app/serializers/upvote_serializer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: upvotes
+#
+#  id          :integer          not null, primary key
+#  veteran_id  :integer
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 class UpvoteSerializer < ActiveModel::Serializer
   attributes :id           
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,7 @@
 Rails.application.routes.draw do
 
+  get 'subscriptions/create'
+
 	# get 'partnering_organizations/sign_up' => 'partnering_organizations#new'
 	# post 'partnering_organizations/' => 'partnering_organizations#create'
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,9 @@ Rails.application.routes.draw do
         patch :reject
       end
     end
+
+    # Subscriptions
+    resources :subscriptions, only: [:create]
   end
 
   resources :resources do

--- a/db/migrate/20171202201757_create_subscriptions.rb
+++ b/db/migrate/20171202201757_create_subscriptions.rb
@@ -1,0 +1,10 @@
+class CreateSubscriptions < ActiveRecord::Migration[5.1]
+  def change
+    create_table :subscriptions do |t|
+      t.references :veteran, foreign_key: true
+      t.references :partnering_organization, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171201052031) do
+ActiveRecord::Schema.define(version: 20171202201757) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -85,6 +85,15 @@ ActiveRecord::Schema.define(version: 20171201052031) do
     t.index ["partnering_organizations_id"], name: "index_resources_on_partnering_organizations_id"
   end
 
+  create_table "subscriptions", force: :cascade do |t|
+    t.bigint "veteran_id"
+    t.bigint "partnering_organization_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["partnering_organization_id"], name: "index_subscriptions_on_partnering_organization_id"
+    t.index ["veteran_id"], name: "index_subscriptions_on_veteran_id"
+  end
+
   create_table "upvotes", force: :cascade do |t|
     t.bigint "veteran_id"
     t.bigint "resource_id"
@@ -124,6 +133,8 @@ ActiveRecord::Schema.define(version: 20171201052031) do
   end
 
   add_foreign_key "resources", "partnering_organizations", column: "partnering_organizations_id"
+  add_foreign_key "subscriptions", "partnering_organizations"
+  add_foreign_key "subscriptions", "veterans"
   add_foreign_key "upvotes", "resources"
   add_foreign_key "upvotes", "veterans"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -77,12 +77,10 @@ ActiveRecord::Schema.define(version: 20171202201757) do
     t.integer "category"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "partnering_organizations_id"
     t.string "owner_type"
     t.bigint "owner_id"
     t.string "description"
     t.index ["owner_type", "owner_id"], name: "index_resources_on_owner_type_and_owner_id"
-    t.index ["partnering_organizations_id"], name: "index_resources_on_partnering_organizations_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|
@@ -120,19 +118,18 @@ ActiveRecord::Schema.define(version: 20171202201757) do
     t.datetime "last_sign_in_at"
     t.inet "current_sign_in_ip"
     t.inet "last_sign_in_ip"
-    t.decimal "lat", precision: 10, scale: 6
-    t.decimal "lng", precision: 10, scale: 6
     t.integer "military_branch"
     t.string "unit"
     t.string "notes"
     t.boolean "accept_messages"
     t.boolean "share_profile"
     t.boolean "accept_notices"
+    t.decimal "lat", precision: 10, scale: 6
+    t.decimal "lng", precision: 10, scale: 6
     t.index ["email"], name: "index_veterans_on_email", unique: true
     t.index ["reset_password_token"], name: "index_veterans_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "resources", "partnering_organizations", column: "partnering_organizations_id"
   add_foreign_key "subscriptions", "partnering_organizations"
   add_foreign_key "subscriptions", "veterans"
   add_foreign_key "upvotes", "resources"

--- a/test/controllers/subscriptions_controller_test.rb
+++ b/test/controllers/subscriptions_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class SubscriptionsControllerTest < ActionDispatch::IntegrationTest
+  test "should get create" do
+    get subscriptions_create_url
+    assert_response :success
+  end
+
+end

--- a/test/fixtures/partnering_organizations.yml
+++ b/test/fixtures/partnering_organizations.yml
@@ -23,6 +23,7 @@
 #  last_sign_in_at        :datetime
 #  current_sign_in_ip     :inet
 #  last_sign_in_ip        :inet
+#  image                  :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/fixtures/resources.yml
+++ b/test/fixtures/resources.yml
@@ -5,12 +5,13 @@
 #  id                          :integer          not null, primary key
 #  file_name                   :string
 #  file                        :string
-#  category                    :string
+#  category                    :integer
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  partnering_organizations_id :integer
 #  owner_type                  :string
 #  owner_id                    :integer
+#  description                 :string
 #
 
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subscriptions
+#
+#  id                         :integer          not null, primary key
+#  veteran_id                 :integer
+#  partnering_organization_id :integer
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:

--- a/test/fixtures/subscriptions.yml
+++ b/test/fixtures/subscriptions.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  veteran: one
+  partnering_organization: one
+
+two:
+  veteran: two
+  partnering_organization: two

--- a/test/fixtures/upvotes.yml
+++ b/test/fixtures/upvotes.yml
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: upvotes
+#
+#  id          :integer          not null, primary key
+#  veteran_id  :integer
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:

--- a/test/models/resource_test.rb
+++ b/test/models/resource_test.rb
@@ -5,12 +5,13 @@
 #  id                          :integer          not null, primary key
 #  file_name                   :string
 #  file                        :string
-#  category                    :string
+#  category                    :integer
 #  created_at                  :datetime         not null
 #  updated_at                  :datetime         not null
 #  partnering_organizations_id :integer
 #  owner_type                  :string
 #  owner_id                    :integer
+#  description                 :string
 #
 
 require 'test_helper'

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class SubscriptionTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/subscription_test.rb
+++ b/test/models/subscription_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: subscriptions
+#
+#  id                         :integer          not null, primary key
+#  veteran_id                 :integer
+#  partnering_organization_id :integer
+#  created_at                 :datetime         not null
+#  updated_at                 :datetime         not null
+#
+
 require 'test_helper'
 
 class SubscriptionTest < ActiveSupport::TestCase

--- a/test/models/upvote_test.rb
+++ b/test/models/upvote_test.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: upvotes
+#
+#  id          :integer          not null, primary key
+#  veteran_id  :integer
+#  resource_id :integer
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
+
 require 'test_helper'
 
 class UpvoteTest < ActiveSupport::TestCase


### PR DESCRIPTION
PO's are now serialized with whether a veteran has subscribed 

```bash
13:12:16:   Object {
13:12:16:     "address": "18224 McKenzie Meadow, Lake Angelotown, MN 68107-9706",
13:12:16:     "demographic": "veterans",
13:12:16:     "id": 11,
13:12:16:     "is_subscribed_to": false,
13:12:16:     "lat": "41.018461",
13:12:16:     "lng": "-75.07646",
13:12:16:     "name": "Conn and Sons",
13:12:16:     "phone_number": "690-920-9424",
13:12:16:     "role": "volunteer_organization",
13:12:16:     "website": "tripodaircomponent.com",
13:12:16:   },
13:12:16: ]
```